### PR TITLE
Add progressive enhancement to the form

### DIFF
--- a/src/routes/game/[slug]/+page.svelte
+++ b/src/routes/game/[slug]/+page.svelte
@@ -2,6 +2,8 @@
 	import type { PageData, ActionData } from './$types';
 	import type { Game } from '$lib/games';
 
+	import { enhance } from '$app/forms';
+
 	export let data: PageData;
 	export let form: ActionData;
 
@@ -14,7 +16,7 @@
 	}
 </script>
 
-<form method="POST">
+<form method="POST" use:enhance>
 	<h2>Select the option that matches: {game.target}</h2>
 
 	<div class="images">


### PR DESCRIPTION
I've switched on SvelteKit's progressive enhancement for the form that contains the image-selecting game. This means that when client-side JavaScript has been downloaded, the game won't send full form submissions back to the server and receive a full updated page in return. But when JavaScript is disabled, the form submission should still work just fine.